### PR TITLE
Fix multi-user credentials

### DIFF
--- a/src/main/java/MChat.java
+++ b/src/main/java/MChat.java
@@ -28,80 +28,27 @@ public class MChat {
      * @param args command line arguments (not used)
      */
     public static void main(String[] args) {
-        // Check if existing credentials exist
-        Properties existingCredentials = CredentialsManager.loadCredentials();
-        String username;
-        User user;
-        boolean isNewUser = false;
-        
-        if (existingCredentials != null) {
-            // User already exists, use existing credentials
-            username = existingCredentials.getProperty("username");
-            System.out.println("[CLIENT] Found existing user: " + username);
-            
-            // Ask if user wants to use existing credentials or create new ones
-            int choice = JOptionPane.showConfirmDialog(
-                null, 
-                "Found existing user: " + username + "\nUse existing credentials?", 
-                "Existing User Found", 
-                JOptionPane.YES_NO_OPTION
-            );
-            
-            if (choice == JOptionPane.YES_OPTION) {
-                // Use existing credentials - this is a login, not a new registration
-                user = new User(username, true, existingCredentials);
-                System.out.println("[CLIENT] Using existing credentials for: " + username);
-                isNewUser = false; // Existing user, will authenticate
-            } else {
-                // User wants to create new account - delete old credentials first
-                CredentialsManager.deleteCredentials();
-                
-                // Create new user
-                LoginDialog loginDialog = new LoginDialog(null);
-                username = loginDialog.showDialog();
-                
-                if (username == null) {
-                    System.err.println("[CLIENT] No username provided, exiting.");
-                    JOptionPane.showMessageDialog(null, "No username provided, exiting.", "Error", JOptionPane.ERROR_MESSAGE);
-                    return;
-                }
-                
-                // Check if this is a newly registered user (has credentials)
-                // If LoginDialog returned successfully, the user is already registered
-                Properties newCredentials = CredentialsManager.loadCredentials();
-                if (newCredentials != null && newCredentials.getProperty("username").equals(username)) {
-                    // User was registered successfully, load their credentials
-                    user = new User(username, true, newCredentials);
-                    isNewUser = false; // User is registered, will authenticate
-                } else {
-                    System.err.println("[CLIENT] Registration may have failed, exiting.");
-                    JOptionPane.showMessageDialog(null, "Registration failed, please try again.", "Error", JOptionPane.ERROR_MESSAGE);
-                    return;
-                }
-            }
-        } else {
-            // No existing credentials, show login dialog
-            LoginDialog loginDialog = new LoginDialog(null);
-            username = loginDialog.showDialog();
-            
-            if (username == null) {
-                System.err.println("[CLIENT] No username provided, exiting.");
-                JOptionPane.showMessageDialog(null, "No username provided, exiting.", "Error", JOptionPane.ERROR_MESSAGE);
-                return;
-            }
-            
-            // Check if user was registered or logged in
-            Properties credentials = CredentialsManager.loadCredentials();
-            if (credentials != null && credentials.getProperty("username").equals(username)) {
-                // User logged in or was just registered
-                user = new User(username, true, credentials);
-                isNewUser = false; // Will authenticate with server
-            } else {
-                System.err.println("[CLIENT] No valid credentials found, exiting.");
-                JOptionPane.showMessageDialog(null, "Login failed, please try again.", "Error", JOptionPane.ERROR_MESSAGE);
-                return;
-            }
+        // Always show login dialog (supports login and registration)
+        LoginDialog loginDialog = new LoginDialog(null);
+        String username = loginDialog.showDialog();
+        if (username == null) {
+            System.err.println("[CLIENT] No username provided, exiting.");
+            JOptionPane.showMessageDialog(null, "No username provided, exiting.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
         }
+
+        // Load RSA credentials for this user if they exist
+        Properties userCredentials = CredentialsManager.loadCredentials(username);
+        User user;
+        if (userCredentials != null) {
+            System.out.println("[CLIENT] Loaded credentials for user: " + username);
+            user = new User(username, true, userCredentials);
+        } else {
+            System.out.println("[CLIENT] No credentials found for user: " + username + " - generating new keys.");
+            user = new User(username); // generates and saves new credentials
+        }
+
+        boolean isNewUser = false; // kept for compatibility, ChatClientEndpoint ignores this
         
         JOptionPane.showMessageDialog(null, "Welcome " + username + "!", "Login Successful", JOptionPane.INFORMATION_MESSAGE);
         System.out.println("[CLIENT] Username: " + username);

--- a/src/main/java/utils/CredentialsManager.java
+++ b/src/main/java/utils/CredentialsManager.java
@@ -60,8 +60,48 @@ public class CredentialsManager {
     }
     
     /**
-     * Load user credentials from file
-     * @return Properties object with user data or null if not found
+     * Load credentials for a specific user from file
+     * @param username the username to load credentials for
+     * @return Properties object containing only the credentials of the given user
+     */
+    public static Properties loadCredentials(String username) {
+        try {
+            File credentialsFile = new File(CREDENTIALS_DIR, CREDENTIALS_FILE);
+            if (!credentialsFile.exists()) {
+                System.out.println("[CLIENT] No existing credentials found.");
+                return null;
+            }
+
+            Properties props = new Properties();
+            try (FileInputStream fis = new FileInputStream(credentialsFile)) {
+                props.load(fis);
+            }
+
+            String prefix = "user." + username + ".";
+            if (!props.containsKey(prefix + "public.n")) {
+                System.out.println("[CLIENT] No credentials found for user: " + username);
+                return null;
+            }
+
+            Properties userProps = new Properties();
+            userProps.setProperty("username", username);
+            userProps.setProperty("public.n", props.getProperty(prefix + "public.n"));
+            userProps.setProperty("public.e", props.getProperty(prefix + "public.e"));
+            userProps.setProperty("private.d", props.getProperty(prefix + "private.d"));
+            userProps.setProperty("registrationTime", props.getProperty(prefix + "registrationTime"));
+
+            System.out.println("[CLIENT] Credentials loaded for user: " + username);
+            return userProps;
+        } catch (IOException e) {
+            System.err.println("[CLIENT] Error loading credentials: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Load all credentials from file without filtering by user
+     * @return Properties of the whole credentials file or null if none exist
      */
     public static Properties loadCredentials() {
         try {
@@ -70,20 +110,47 @@ public class CredentialsManager {
                 System.out.println("[CLIENT] No existing credentials found.");
                 return null;
             }
-            
+
             Properties props = new Properties();
-            try (FileInputStream fis = new FileInputStream(credentialsFile)) { // Using try-with-resources for automatic closing and a File Stream
+            try (FileInputStream fis = new FileInputStream(credentialsFile)) {
                 props.load(fis);
             }
-            
-            String username = props.getProperty("username");
-            System.out.println("[CLIENT] Credentials loaded for user: " + username);
+
             return props;
         } catch (IOException e) {
             System.err.println("[CLIENT] Error loading credentials: " + e.getMessage());
             e.printStackTrace();
             return null;
         }
+    }
+
+    /**
+     * Get a list of usernames for which credentials exist
+     */
+    public static java.util.List<String> getRegisteredUsernames() {
+        java.util.List<String> users = new java.util.ArrayList<>();
+        try {
+            File credentialsFile = new File(CREDENTIALS_DIR, CREDENTIALS_FILE);
+            if (!credentialsFile.exists()) {
+                return users;
+            }
+            Properties props = new Properties();
+            try (FileInputStream fis = new FileInputStream(credentialsFile)) {
+                props.load(fis);
+            }
+
+            for (String key : props.stringPropertyNames()) {
+                if (key.startsWith("user.") && key.endsWith(".public.n")) {
+                    String name = key.substring("user.".length(), key.length() - ".public.n".length());
+                    if (!users.contains(name)) {
+                        users.add(name);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("[CLIENT] Error reading credentials: " + e.getMessage());
+        }
+        return users;
     }
     
     /**


### PR DESCRIPTION
## Summary
- support loading credentials for individual users
- simplify client startup logic to always prompt for login

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686bf818baec8325967e80198c22dcc8